### PR TITLE
Fixed negative value display along with very large positive values. 

### DIFF
--- a/TS SE Tool/CustomClasses/Save/Items/PlayerData.cs
+++ b/TS SE Tool/CustomClasses/Save/Items/PlayerData.cs
@@ -23,7 +23,7 @@ namespace TS_SE_Tool
         public uint ExperiencePoints { get; set; } = 0;
         public byte[] PlayerSkills { get; set; } = new byte[] { 0, 0, 0, 0, 0, 0 };
         //Bank
-        public uint AccountMoney { get; set; } = 0;
+        public long AccountMoney { get; set; } = 0;
         //Player
         public string HQcity { get; set; } = "";
         public string UserCompanyAssignedTruck { get; set; } = "";

--- a/TS SE Tool/CustomClasses/Save/SaveFileInfoData.cs
+++ b/TS SE Tool/CustomClasses/Save/SaveFileInfoData.cs
@@ -36,7 +36,7 @@ namespace TS_SE_Tool
         private ushort InfoUnlockedRecruitments { get; set; } = 0;
         private ushort InfoUnlockedDealers { get; set; } = 0;
         private ushort InfoVisitedCities { get; set; } = 0;
-        private uint InfoMoneyAccount { get; set; } = 0;
+        private long InfoMoneyAccount { get; set; } = 0;
         private decimal InfoExploredRatio { get; set; } = 0.0M;
 
         internal List<Dependency> Dependencies { get; set; }
@@ -185,7 +185,7 @@ namespace TS_SE_Tool
                 if (_FileLines[line].StartsWith(" info_money_account:"))
                 {
                     chunkOfline = _FileLines[line].Split(new char[] { ' ' });
-                    InfoMoneyAccount = uint.Parse(chunkOfline[2]);
+                    InfoMoneyAccount = long.Parse(chunkOfline[2]);
                     continue;
                 }
 

--- a/TS SE Tool/DataManipulation.cs
+++ b/TS SE Tool/DataManipulation.cs
@@ -374,7 +374,7 @@ namespace TS_SE_Tool
                     if (tempSavefileInMemory[line].StartsWith(" money_account:"))
                     {
                         chunkOfline = tempSavefileInMemory[line].Split(new char[] { ' ' });
-                        PlayerDataData.AccountMoney = uint.Parse(chunkOfline[2]);
+                        PlayerDataData.AccountMoney = long.Parse(chunkOfline[2]);
                         continue;
                     }
 

--- a/TS SE Tool/Forms/MainTabs/FormMethodsCompanyTab.cs
+++ b/TS SE Tool/Forms/MainTabs/FormMethodsCompanyTab.cs
@@ -62,7 +62,7 @@ namespace TS_SE_Tool
 
         public void FillAccountMoneyTB()
         {
-            UInt64 valueBefore = (uint)Math.Floor(PlayerDataData.AccountMoney * CurrencyDictConversion[Globals.CurrencyName]);
+            Int64 valueBefore = (long)Math.Floor(PlayerDataData.AccountMoney * CurrencyDictConversion[Globals.CurrencyName]);
 
             string newtext = "";
             if (CurrencyDictFormat[Globals.CurrencyName][0] != "")
@@ -163,9 +163,9 @@ namespace TS_SE_Tool
                 int testV = textBoxAccountMoney.SelectionStart;
 
                 string onlyDigits = new string(textBoxAccountMoney.Text.Where(c => char.IsDigit(c)).ToArray());
-                if (!UInt64.TryParse(onlyDigits, NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out ulong valueBefore))
+                if (!Int64.TryParse(onlyDigits, NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out long valueBefore))
                 {
-                    valueBefore = UInt64.MaxValue;
+                    valueBefore = Int64.MaxValue;
                 }
                 //[sign1] - [sign2] 1.234,- [sign3]
                 if (CurrencyDictFormat[Globals.CurrencyName][0] != "")
@@ -183,14 +183,14 @@ namespace TS_SE_Tool
 
                 textBoxAccountMoney.SelectionStart = testV + cSpace2 - cSpace1;
 
-                PlayerDataData.AccountMoney = (uint)Math.Round(valueBefore / CurrencyDictConversion[Globals.CurrencyName]);
+                PlayerDataData.AccountMoney = (long)Math.Round(valueBefore / CurrencyDictConversion[Globals.CurrencyName]);
             }
         }
 
         private void textBoxMoneyAccount_KeyPress(object sender, KeyPressEventArgs e)
         {
             TextBox textBoxAccountMoney = sender as TextBox;
-            UInt64 valueBefore = 0;
+            Int64 valueBefore = 0;
             string onlyDigits = new string(textBoxAccountMoney.Text.Where(c => char.IsDigit(c)).ToArray());
 
             int testV = textBoxAccountMoney.SelectionStart;
@@ -204,14 +204,14 @@ namespace TS_SE_Tool
                         return;
                     }
 
-                    if (UInt64.TryParse(onlyDigits, NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out valueBefore))
+                    if (Int64.TryParse(onlyDigits, NumberStyles.AllowThousands, CultureInfo.CurrentCulture, out valueBefore))
                     {
                         textBoxAccountMoney.Text = valueBefore.ToString();
                         e.Handled = true;
                     }
                     else
                     {
-                        valueBefore = UInt64.MaxValue;
+                        valueBefore =Int64.MaxValue;
                         textBoxAccountMoney.Text = valueBefore.ToString();
                         e.Handled = true;
                     }


### PR DESCRIPTION
The game uses signed 64-bit integer to store profile's money account. This program tries to parse that as unsigned 32-bit integer. Exception was being thrown when profile's save file has more than 2^32 Euros, or has less than 0 Euros. 
Fixes #31